### PR TITLE
Default array should be created only if the key is a number and the index is in order

### DIFF
--- a/lib/util/defaultObject.js
+++ b/lib/util/defaultObject.js
@@ -1,16 +1,18 @@
 import isEmpty from './isEmpty';
 
-function isInt(value) {
+function isIntAndInRange(value, maxIndex) {
   if (isNaN(value)) {
     return false;
   }
   const x = parseFloat(value);
-  return (x | 0) === x;
+  return (x | 0) === x && (x >= 0 && x <= maxIndex);
 }
 
 function isArrayUpdate(updates) {
-  for (const updateKey of Object.keys(updates)) {
-    if (!isInt(updateKey)) { return false; }
+  const keys = Object.keys(updates);
+  const maxIndex = keys.length - 1;
+  for (const updateKey of keys) {
+    if (!isIntAndInRange(updateKey, maxIndex)) { return false; }
   }
 
   return true;

--- a/test/updeep-spec.js
+++ b/test/updeep-spec.js
@@ -54,6 +54,18 @@ describe('updeep', () => {
     expect(result).to.eql({ 0: 'hi', '1a': 'world' });
   });
 
+  it('can create array if all keys are numbers and the index is in order from zero', () => {
+    const result = u({ 0: 'hi', '1': 'world', 2: 'ind2' }, null);
+
+    expect(result).to.eql(['hi', 'world', 'ind2']);
+  });
+
+  it('doest not create array if all keys are numbers but the index is not in order from zero', () => {
+    const result = u({ 0: 'hi', '2': 'world', 3: 'ind3' }, null);
+
+    expect(result).to.eql({ 0: 'hi', '2': 'world', 3: 'ind3' });
+  });
+
   it('can add an element to an array', () => {
     const object = [];
     const result = u({ 0: 3 }, object);


### PR DESCRIPTION
The use case is when i use updeep to update the entities that normalized from normalizr package (https://github.com/gaearon/normalizr) and the ids are number.

But this will not fix the problem if the updated ids is happen to be in order (luckily most database has an incremental id field begins from 1 haha).

In my opinion, If there is an existing array, the update operation makes sense. But if there is no existing array, the new array should not be created 

What do you think?