### PR TITLE
Make lodash a normal dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "bugs": {
     "url": "https://github.com/aaronjensen/updeep/issues"
   },
-  "peerDependencies": {
+  "dependencies": {
     "lodash": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Make lodash a dependency instead of a peerDependency.

Fixes #43