### PR TITLE
Allow updeep to be require()’d from CommonJS

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,4 +26,4 @@ u.update = update;
 u.updateIn = updateIn;
 u.withDefault = withDefault;
 
-export default u;
+module.exports = u;


### PR DESCRIPTION
The latest updeep from npm:

```
$ npm install updeep
└─┬ updeep@0.13.0
  └── lodash@4.6.1
```

I cannot use `updeep` by requiring from CommonJS module:

```
$ node
> var object = { enabled: true }
> var u = require('updeep')
> u({ enabled: x => !x }, object)
TypeError: u is not a function
    at repl:1:1
    at REPLServer.defaultEval (repl.js:252:27)
    at bound (domain.js:287:14)
    at REPLServer.runBound [as eval] (domain.js:300:12)
    at REPLServer.<anonymous> (repl.js:417:12)
    at emitOne (events.js:95:20)
    at REPLServer.emit (events.js:182:7)
    at REPLServer.Interface._onLine (readline.js:211:10)
    at REPLServer.Interface._line (readline.js:550:8)
    at REPLServer.Interface._ttyWrite (readline.js:827:14)
```

Babel 6 no longer exports the default export directly to `module.exports`. It will export to `exports.default`, which means it needs to be required like this:

```
> var u = require('updeep').default
> u({ enabled: x => !x }, object)
{ enabled: false }
```

Ok it works now.

Currently we’re using updeep in Node environment as well — which does not support ES6 modules yet.