### PR TITLE
Overwriting arrays with objects.

### DIFF
--- a/test/updeep-spec.js
+++ b/test/updeep-spec.js
@@ -140,4 +140,16 @@ describe('updeep', () => {
     const result = u({ created: date }, {});
     expect(result).to.eql({ created: date });
   });
+
+  it('can overwrite an array child with an object', () => {
+    const parent = {
+      child: [],
+    };
+    const newChild = {
+    };
+    const newParent = u({
+      child: newChild,
+    }, parent);
+    expect(newParent.child).to.eql(newChild);
+  });
 });


### PR DESCRIPTION
Added a failing test case to show the problem I'm having with `updeep`.

```JS
  it('can overwrite an array child with an object', () => {
    const parent = {
      child: [],
    };
    const newChild = {
    };
    const newParent = u({
      child: newChild,
    }, parent);
    expect(newParent.child).to.eql(newChild);
  });
```

Is this a valid use case?