### PR TITLE
u.reject should return same instance if no changes.

### DIFF
--- a/lib/reject.js
+++ b/lib/reject.js
@@ -2,7 +2,12 @@ import _reject from 'lodash/reject';
 import wrap from './wrap';
 
 function reject(predicate, collection) {
-  return _reject(collection, predicate);
+  const result = _reject(collection, predicate);
+  const equal = collection.length === result.length;
+
+  return equal ?
+    collection :
+    result;
 }
 
 export default wrap(reject);

--- a/test/reject-spec.js
+++ b/test/reject-spec.js
@@ -14,6 +14,15 @@ describe('u.reject', () => {
     expect(result).to.eql([{ bad: false }]);
   });
 
+  it('returns the same instance if reject doesn\'t make changes', () => {
+    const object = { foo: [1, 2, 3] };
+    const result = u({
+      foo: u.reject(x => x === 'Justin Bieber'),
+    }, object);
+
+    expect(result).to.equal(object);
+  });
+
   it('freezes the result', () => {
     expect(Object.isFrozen(u.reject('a', []))).to.be.true;
   });

--- a/test/reject-spec.js
+++ b/test/reject-spec.js
@@ -23,6 +23,15 @@ describe('u.reject', () => {
     expect(result).to.equal(object);
   });
 
+  it('returns a different instance if reject makes changes', () => {
+    const object = { foo: [1, 2, 3, 4] };
+    const result = u({
+      foo: u.reject(x => x === 4),
+    }, object);
+
+    expect(result).to.not.equal(object);
+  });
+
   it('freezes the result', () => {
     expect(Object.isFrozen(u.reject('a', []))).to.be.true;
   });


### PR DESCRIPTION
Added failing test.

Thoughts on this one?
I think it's fair to expect `u.reject` to maintain the promise made by `u.update`.

Unsure of what is the best way to solve, since `u.reject` uses `lodash.reject` internally, which always returns a new instance. Aside from writing a custom reject, perhaps the only way is to do a `lodash.isEqual` deep equals after each `reject`.
