### PR TITLE
Allow Number type in updateIn function

### DIFF
--- a/lib/util/splitPath.js
+++ b/lib/util/splitPath.js
@@ -1,8 +1,7 @@
 import reject from 'lodash/reject';
-import toString from 'lodash/toString';
 
 export default function splitPath(path) {
   return Array.isArray(path) ?
     path :
-    reject(toString(path).split('.'), x => !x);
+    reject((path + '').split('.'), x => !x);
 }

--- a/lib/util/splitPath.js
+++ b/lib/util/splitPath.js
@@ -1,7 +1,8 @@
 import reject from 'lodash/reject';
+import toString from 'lodash/toString';
 
 export default function splitPath(path) {
   return Array.isArray(path) ?
     path :
-    reject(path.split('.'), x => !x);
+    reject(toString(path).split('.'), x => !x);
 }

--- a/test/util/splitPath-spec.js
+++ b/test/util/splitPath-spec.js
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+import splitPath from '../../lib/util/splitPath';
+
+describe('splitPath', () => {
+  it('test number path', () => {
+    const path = 1;
+    const result = splitPath(path);
+    expect(result).to.deep.equal(['1']);
+  });
+  it('test number path', () => {
+    const path = 0;
+    const result = splitPath(path);
+    expect(result).to.deep.equal(['0']);
+  });
+  it('test array path', () => {
+    const path = ['foo', 'bar', 'x'];
+    const result = splitPath(path);
+    expect(result).to.equal(path);
+  });
+  it('test string path', () => {
+    const path = 'bar.0.y';
+    const result = splitPath(path);
+    expect(result).to.deep.equal(['bar', '0', 'y']);
+  });
+});

--- a/test/util/splitPath-spec.js
+++ b/test/util/splitPath-spec.js
@@ -2,22 +2,19 @@ import { expect } from 'chai';
 import splitPath from '../../lib/util/splitPath';
 
 describe('splitPath', () => {
-  it('test number path', () => {
+  it('treats a number as a single step path', () => {
     const path = 1;
     const result = splitPath(path);
     expect(result).to.deep.equal(['1']);
   });
-  it('test number path', () => {
-    const path = 0;
-    const result = splitPath(path);
-    expect(result).to.deep.equal(['0']);
-  });
-  it('test array path', () => {
+
+  it('handles arrays', () => {
     const path = ['foo', 'bar', 'x'];
     const result = splitPath(path);
     expect(result).to.equal(path);
   });
-  it('test string path', () => {
+
+  it('handles strings separated by dots', () => {
     const path = 'bar.0.y';
     const result = splitPath(path);
     expect(result).to.deep.equal(['bar', '0', 'y']);


### PR DESCRIPTION
Test case:

```js
u.updateIn(0, 123, [1, 2, 3]);
```

Before output:
```console
     TypeError: path.split is not a function
      at splitPath (lib/util/splitPath.js:7:17)
```

After:
```
[123, 2, 3]
```