### PR TITLE
Close `u.omit` example code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ var user = {
 var result = u({ user: u.omit(['authToken', 'SSN']) }, user);
 
 expect(result).to.eql({ user: { email: 'john@aol.com', username: 'john123' } });
+```
 
 ### `u.omitted`
 


### PR DESCRIPTION
Looks like someone forgot to close the code block before the `u.omitted` heading in the readme.