### PR TITLE
Reject on objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ expect(result).to.eql({ user: { email: 'john@aol.com', username: 'john123', auth
 
 ### `u.reject(predicate(, object))`
 
-Reject items from an array. See [`_.reject`](https://lodash.com/docs#reject).
+Reject items from an array or object. See [`_.reject`](https://lodash.com/docs#reject).
 
 ```js
 function isEven(i) { return i % 2 === 0; }

--- a/lib/reject.js
+++ b/lib/reject.js
@@ -3,7 +3,9 @@ import wrap from './wrap'
 
 function reject(predicate, collection) {
   const result = _reject(collection, predicate)
-  const equal = collection.length === result.length
+  const equal = Array.isArray(collection)
+    ? collection.length === result.length
+    : Object.keys(collection).length === result.length
 
   return equal ? collection : result
 }

--- a/test/reject-spec.js
+++ b/test/reject-spec.js
@@ -41,4 +41,10 @@ describe('u.reject', () => {
   it('freezes the result', () => {
     expect(Object.isFrozen(u.reject('a', []))).to.be.true
   })
+
+  it('works on objects too', () => {
+    expect(
+      u.reject('goner', { a: { one: 1 }, b: { goner: true }, c: { two: 2 } })
+    ).to.eql([{ one: 1 }, { two: 2 }])
+  })
 })


### PR DESCRIPTION
lodash's reject can work on objects too. The only required change on the updeep side of things is to check the length of the object's keys when appropriate.  