### PR TITLE
Make array manipulation helpers explicit in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,13 +164,16 @@ expect(result).to.eql({ scores: { team1: 0, team2: 1 } });
 Non-trivial array manipulations, such as element removal/insertion/sorting, can be implemented with functions. Because there are so many possible manipulations, we don't provide any helpers and leave this up to you. Simply ensure your function is pure and does not mutate its arguments.
 
 ```js
-function addTodo(todos) { return [].concat(todos, [{ done: false }]); }
 var state = {
   todos: [
     { done: false },
     { done: false }
   ]
 };
+
+var newTodo = { done: false };
+var addTodo = existingTodos => [...existingTodos, newTodo];
+
 var result = u({ todos: addTodo }, state);
 
 expect(result).to.eql({ todos: [{ done: false }, { done: false }, { done: false }]});


### PR DESCRIPTION
Rename the argument of addTodo so that it's clear where all the data used in the helper function comes from.

Also updated to use modern JS syntax with widespread support:
[spread operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Browser_compatibility)
[arrow function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#Browser_compatibility) 
