### PR TITLE
add the two argument curried version of updateIn

### DIFF
--- a/types/updateIn.d.ts
+++ b/types/updateIn.d.ts
@@ -1,12 +1,11 @@
 import { Path } from './types';
 export declare function updateIn(path: Path, value: any, object: any): any;
-interface Curry2 {
-    (value: any, object: any): any;
-    (value: any): (object: any) => any;
-}
-interface CurriedUpdateIn {
-    (path: Path, value: any, object: any): any;
-    (path: Path): Curry2;
-}
-declare const _default: CurriedUpdateIn;
+declare const _default: {
+    (a: any): {
+        (a: any): (a: any) => any;
+        (a: any, b: any): any;
+    };
+    (a: any, b: any): (a: any) => any;
+    (a: any, b: any, c: any): any;
+};
 export default _default;


### PR DESCRIPTION
updateIn only had signatures for `(a,b,c)` and `(a) => (b,c)` but was missing `(a) => (b) => (c)`.

The typescript branch generating the types has been simplified to use generic variadic curries (see https://github.com/substantial/updeep/commit/ba8ce6151e153e579ee721612e4fcbdcf0ae871b#diff-f0110f871bbb78393553f89381b8a4fdR49)