### PR TITLE
Add check for process for browser context

### DIFF
--- a/lib/freeze.js
+++ b/lib/freeze.js
@@ -38,6 +38,11 @@ function recur(object) {
  * @return {object} Frozen object, unless in production, then the same object.
  */
 function freeze(object) {
+  // is `process` defined? I.e., are we in a browser?
+  if( typeof process === 'undefined' ) {
+      return object;
+  }
+
   if (process.env.NODE_ENV === 'production') {
     return object
   }


### PR DESCRIPTION
ensure process exists before using it, as process doesn't exist at all in
a browser context.