### PR TITLE
don't change the original object if there were no updates

### DIFF
--- a/lib/omit.js
+++ b/lib/omit.js
@@ -1,8 +1,6 @@
 import _omit from 'lodash/omit'
 import wrap from './wrap'
-
-export const size = (obj) =>
-  Array.isArray(obj) ? obj.length : Object.keys(obj).length
+import size from './util/size'
 
 function omit(predicate, collection) {
   const result = _omit(collection, predicate)

--- a/lib/omit.js
+++ b/lib/omit.js
@@ -1,7 +1,7 @@
 import _omit from 'lodash/omit'
 import wrap from './wrap'
 
-const size = (obj) =>
+export const size = (obj) =>
   Array.isArray(obj) ? obj.length : Object.keys(obj).length
 
 function omit(predicate, collection) {

--- a/lib/omit.js
+++ b/lib/omit.js
@@ -1,6 +1,8 @@
 import _omit from 'lodash/omit'
-import size from 'lodash/size'
 import wrap from './wrap'
+
+const size = (obj) =>
+  Array.isArray(obj) ? obj.length : Object.keys(obj).length
 
 function omit(predicate, collection) {
   const result = _omit(collection, predicate)

--- a/lib/omit.js
+++ b/lib/omit.js
@@ -4,7 +4,13 @@ import size from './util/size'
 
 function omit(predicate, collection) {
   const result = _omit(collection, predicate)
-  return size(result) === size(collection) ? collection : result
+
+  const changed = size(result) !== size(collection)
+  if (changed) {
+    return result
+  } else {
+    return collection
+  }
 }
 
 export default wrap(omit)

--- a/lib/omit.js
+++ b/lib/omit.js
@@ -1,8 +1,10 @@
 import _omit from 'lodash/omit'
+import size from 'lodash/size'
 import wrap from './wrap'
 
 function omit(predicate, collection) {
-  return _omit(collection, predicate)
+  const result = _omit(collection, predicate)
+  return size(result) === size(collection) ? collection : result
 }
 
 export default wrap(omit)

--- a/lib/omitBy.js
+++ b/lib/omitBy.js
@@ -4,7 +4,13 @@ import wrap from './wrap'
 
 function omitBy(predicate, collection) {
   const result = _omitBy(collection, predicate)
-  return size(result) === size(collection) ? collection : result
+
+  const changed = size(result) !== size(collection)
+  if (changed) {
+    return result
+  } else {
+    return collection
+  }
 }
 
 export default wrap(omitBy)

--- a/lib/omitBy.js
+++ b/lib/omitBy.js
@@ -1,5 +1,5 @@
 import _omitBy from 'lodash/omitBy'
-import size from 'lodash/size'
+import { size } from './omit'
 import wrap from './wrap'
 
 function omitBy(predicate, collection) {

--- a/lib/omitBy.js
+++ b/lib/omitBy.js
@@ -1,5 +1,5 @@
 import _omitBy from 'lodash/omitBy'
-import { size } from './omit'
+import size from './util/size'
 import wrap from './wrap'
 
 function omitBy(predicate, collection) {

--- a/lib/omitBy.js
+++ b/lib/omitBy.js
@@ -1,8 +1,10 @@
 import _omitBy from 'lodash/omitBy'
+import size from 'lodash/size'
 import wrap from './wrap'
 
 function omitBy(predicate, collection) {
-  return _omitBy(collection, predicate)
+  const result = _omitBy(collection, predicate)
+  return size(result) === size(collection) ? collection : result
 }
 
 export default wrap(omitBy)

--- a/lib/update.js
+++ b/lib/update.js
@@ -87,10 +87,14 @@ function update(updates, object, ...args) {
 
   // Remove the u.omitted updates on keys that aren't there,
   // in order to avoid creating a copy of the original object
-  Object.entries(resolvedUpdates)
-    .filter(([_, value]) => value === innerOmitted)
-    .filter(([key]) => !defaultedObject.hasOwnProperty(key))
-    .forEach(([key]) => delete resolvedUpdates[key])
+  Object.entries(
+    resolvedUpdates -
+      Object.entries(resolvedUpdates).forEach(([key, value]) => {
+        if (value === innerOmitted) {
+          if (!defaultedObject.hasOwnProperty(key)) delete resolvedUpdates[key]
+        }
+      })
+  )
 
   if (isEmpty(resolvedUpdates)) {
     return defaultedObject

--- a/lib/update.js
+++ b/lib/update.js
@@ -87,14 +87,11 @@ function update(updates, object, ...args) {
 
   // Remove the u.omitted updates on keys that aren't there,
   // in order to avoid creating a copy of the original object
-  Object.entries(
-    resolvedUpdates -
-      Object.entries(resolvedUpdates).forEach(([key, value]) => {
-        if (value === innerOmitted) {
-          if (!defaultedObject.hasOwnProperty(key)) delete resolvedUpdates[key]
-        }
-      })
-  )
+  Object.entries(resolvedUpdates).forEach(([key, value]) => {
+    if (value === innerOmitted) {
+      if (!defaultedObject.hasOwnProperty(key)) delete resolvedUpdates[key]
+    }
+  })
 
   if (isEmpty(resolvedUpdates)) {
     return defaultedObject

--- a/lib/update.js
+++ b/lib/update.js
@@ -4,7 +4,7 @@ import _omitBy from 'lodash/omitBy'
 import wrap from './wrap'
 import constant from './constant'
 
-const innerOmitted = { __omitted: true }
+const innerOmitted = {__omitted: true}
 export const omitted = constant(innerOmitted)
 
 function isEmpty(object) {
@@ -85,11 +85,14 @@ function update(updates, object, ...args) {
 
   const resolvedUpdates = resolveUpdates(updates, defaultedObject)
 
-  Object.entries(resolvedUpdates).forEach(([key, value]) => {
-    if (value === innerOmitted) {
-      if (!defaultedObject.hasOwnProperty(key)) delete resolvedUpdates[key]
-    }
-  })
+  // remove the u.omitted updates on keys that aren't there,
+  // as they are no-op (which is no big deal) but would result in
+  // creating a copy of the original object (which is what we
+  // want to avoid).
+  Object.entries(resolvedUpdates)
+    .filter(([_, value]) => value === innerOmitted)
+    .filter(([key]) => !defaultedObject.hasOwnProperty(key))
+    .forEach(([key]) => delete resolvedUpdates[key])
 
   if (isEmpty(resolvedUpdates)) {
     return defaultedObject
@@ -102,7 +105,7 @@ function update(updates, object, ...args) {
   }
 
   return _omitBy(
-    { ...defaultedObject, ...resolvedUpdates },
+    {...defaultedObject, ...resolvedUpdates},
     (value) => value === innerOmitted
   )
 }

--- a/lib/update.js
+++ b/lib/update.js
@@ -4,7 +4,7 @@ import _omitBy from 'lodash/omitBy'
 import wrap from './wrap'
 import constant from './constant'
 
-const innerOmitted = {__omitted: true}
+const innerOmitted = { __omitted: true }
 export const omitted = constant(innerOmitted)
 
 function isEmpty(object) {
@@ -104,7 +104,7 @@ function update(updates, object, ...args) {
   }
 
   return _omitBy(
-    {...defaultedObject, ...resolvedUpdates},
+    { ...defaultedObject, ...resolvedUpdates },
     (value) => value === innerOmitted
   )
 }

--- a/lib/update.js
+++ b/lib/update.js
@@ -85,6 +85,12 @@ function update(updates, object, ...args) {
 
   const resolvedUpdates = resolveUpdates(updates, defaultedObject)
 
+  Object.entries(resolvedUpdates).forEach(([key, value]) => {
+    if (value === innerOmitted) {
+      if (!defaultedObject.hasOwnProperty(key)) delete resolvedUpdates[key]
+    }
+  })
+
   if (isEmpty(resolvedUpdates)) {
     return defaultedObject
   }

--- a/lib/update.js
+++ b/lib/update.js
@@ -34,7 +34,7 @@ function resolveUpdates(updates, object) {
         updatedValue = value(object[key])
       }
 
-      if (object[key] !== updatedValue) {
+      if (isUpdateChange(updatedValue, key, object)) {
         acc[key] = updatedValue // eslint-disable-line no-param-reassign
       }
 
@@ -42,6 +42,15 @@ function resolveUpdates(updates, object) {
     },
     {}
   )
+}
+
+function isUpdateChange(value, key, object) {
+  // Omitting a property that does not exist is not a change
+  if (value === innerOmitted) {
+    return object.hasOwnProperty(key)
+  } else {
+    return object[key] !== value
+  }
 }
 
 function updateArray(updates, object) {
@@ -84,14 +93,6 @@ function update(updates, object, ...args) {
     typeof object === 'undefined' || object === null ? {} : object
 
   const resolvedUpdates = resolveUpdates(updates, defaultedObject)
-
-  // Remove the u.omitted updates on keys that aren't there,
-  // in order to avoid creating a copy of the original object
-  Object.entries(resolvedUpdates).forEach(([key, value]) => {
-    if (value === innerOmitted) {
-      if (!defaultedObject.hasOwnProperty(key)) delete resolvedUpdates[key]
-    }
-  })
 
   if (isEmpty(resolvedUpdates)) {
     return defaultedObject

--- a/lib/update.js
+++ b/lib/update.js
@@ -85,10 +85,8 @@ function update(updates, object, ...args) {
 
   const resolvedUpdates = resolveUpdates(updates, defaultedObject)
 
-  // remove the u.omitted updates on keys that aren't there,
-  // as they are no-op (which is no big deal) but would result in
-  // creating a copy of the original object (which is what we
-  // want to avoid).
+  // Remove the u.omitted updates on keys that aren't there,
+  // in order to avoid creating a copy of the original object
   Object.entries(resolvedUpdates)
     .filter(([_, value]) => value === innerOmitted)
     .filter(([key]) => !defaultedObject.hasOwnProperty(key))

--- a/lib/util/size.js
+++ b/lib/util/size.js
@@ -1,0 +1,7 @@
+export default function size(obj) {
+  if (Array.isArray(obj)) {
+    return obj.length
+  } else {
+    return Object.keys(obj).length
+  }
+}

--- a/test/omit-spec.js
+++ b/test/omit-spec.js
@@ -11,4 +11,10 @@ describe('u.omit', () => {
   it('freezes the result', () => {
     expect(Object.isFrozen(u.omit('a', {}))).to.be.true
   })
+
+  it("doesn't change the obj if nothing is omitted", () => {
+    const orig = {a: 1}
+    const result = u.omit(['b'], orig)
+    expect(result).to.be.equal(orig)
+  })
 })

--- a/test/omit-spec.js
+++ b/test/omit-spec.js
@@ -13,7 +13,7 @@ describe('u.omit', () => {
   })
 
   it("doesn't change the obj if nothing is omitted", () => {
-    const orig = {a: 1}
+    const orig = { a: 1 }
     const result = u.omit(['b'], orig)
     expect(result).to.be.equal(orig)
   })

--- a/test/omit-spec.js
+++ b/test/omit-spec.js
@@ -12,7 +12,7 @@ describe('u.omit', () => {
     expect(Object.isFrozen(u.omit('a', {}))).to.be.true
   })
 
-  it("doesn't change the obj if nothing is omitted", () => {
+  it("doesn't change the object if nothing is omitted", () => {
     const orig = { a: 1 }
     const result = u.omit(['b'], orig)
     expect(result).to.be.equal(orig)

--- a/test/omitBy-spec.js
+++ b/test/omitBy-spec.js
@@ -16,7 +16,7 @@ describe('u.omitBy', () => {
     expect(Object.isFrozen(u.omit('a', {}))).to.be.true
   })
 
-  it("doesn't change the obj if nothing is omitted", () => {
+  it("doesn't change the object if nothing is omitted", () => {
     const orig = { a: 1 }
     const result = u.omitBy(() => false, orig)
     expect(result).to.be.equal(orig)

--- a/test/omitBy-spec.js
+++ b/test/omitBy-spec.js
@@ -17,7 +17,7 @@ describe('u.omitBy', () => {
   })
 
   it("doesn't change the obj if nothing is omitted", () => {
-    const orig = {a: 1}
+    const orig = { a: 1 }
     const result = u.omitBy(() => false, orig)
     expect(result).to.be.equal(orig)
   })

--- a/test/omitBy-spec.js
+++ b/test/omitBy-spec.js
@@ -15,4 +15,10 @@ describe('u.omitBy', () => {
   it('freezes the result', () => {
     expect(Object.isFrozen(u.omit('a', {}))).to.be.true
   })
+
+  it("doesn't change the obj if nothing is omitted", () => {
+    const orig = {a: 1}
+    const result = u.omitBy(() => false, orig)
+    expect(result).to.be.equal(orig)
+  })
 })

--- a/test/updeep-spec.js
+++ b/test/updeep-spec.js
@@ -172,7 +172,7 @@ describe('updeep', () => {
     })
   })
 
-  it("doesn't change the obj if nothing is omitted", () => {
+  it("doesn't change the object if nothing is omitted", () => {
     const orig = { a: 1 }
     const result = u({ b: u.omitted }, orig)
     expect(result).to.be.equal(orig)

--- a/test/updeep-spec.js
+++ b/test/updeep-spec.js
@@ -173,14 +173,14 @@ describe('updeep', () => {
   })
 
   it("doesn't change the obj if nothing is omitted", () => {
-    const orig = {a: 1}
-    const result = u({b: u.omitted}, orig)
+    const orig = { a: 1 }
+    const result = u({ b: u.omitted }, orig)
     expect(result).to.be.equal(orig)
   })
 
   it("doesn't change the array if nothing is omitted", () => {
     const orig = [1, 2, 3]
-    const result = u({4: u.omitted}, orig)
+    const result = u({ 4: u.omitted }, orig)
     expect(result).to.be.equal(orig)
   })
 })

--- a/test/updeep-spec.js
+++ b/test/updeep-spec.js
@@ -171,4 +171,16 @@ describe('updeep', () => {
       expectU(u({ 1: u.omitted }), ['a', 'b', 'c'], ['a', 'c'])
     })
   })
+
+  it("doesn't change the obj if nothing is omitted", () => {
+    const orig = {a: 1}
+    const result = u({b: u.omitted}, orig)
+    expect(result).to.be.equal(orig)
+  })
+
+  it("doesn't change the array if nothing is omitted", () => {
+    const orig = [1, 2, 3]
+    const result = u({4: u.omitted}, orig)
+    expect(result).to.be.equal(orig)
+  })
 })


### PR DESCRIPTION
I noticed a few of the util functions will return a new object, even if there is no update.  