### PR TITLE
fix explosion in size function and update readme test/lint commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,7 +540,7 @@ case.
 
 1. Fork it.
 1. Create your feature branch (`git checkout -b my-new-feature`).
-1. Run `gulp` to run tests and lint.
+1. Run `yarn test` and `yarn dtslint` to run tests and lint.
 1. Commit your changes (`git commit -am 'Added some feature'`).
 1. Push to the branch (`git push origin my-new-feature`).
 1. Create new Pull Request.

--- a/lib/util/size.js
+++ b/lib/util/size.js
@@ -1,5 +1,7 @@
 export default function size(obj) {
-  if (Array.isArray(obj)) {
+  if (!obj) {
+    return 0;
+  } else if (Array.isArray(obj)) {
     return obj.length
   } else {
     return Object.keys(obj).length

--- a/test/util/size-spec.js
+++ b/test/util/size-spec.js
@@ -1,0 +1,22 @@
+import { expect } from 'chai'
+import size from '../../lib/util/size'
+
+describe('size', () => {
+  it('handles null values', () => {
+    const obj = null
+    const result = size(obj)
+    expect(result).to.equal(0)
+  })
+
+  it('handles arrays', () => {
+    const obj = ['foo', 'bar', 'x']
+    const result = size(obj)
+    expect(result).to.equal(3)
+  })
+
+  it('handles objects', () => {
+    const obj = { foo: "bar" }
+    const result = size(obj)
+    expect(result).to.equal(1)
+  })
+})


### PR DESCRIPTION
Ran into an issue where the new size function was being passed `null` which led to an error.

Also noticed the readme had outdated info on running the tests/linter.